### PR TITLE
[WHIR-3068] Add ability to add app level icons

### DIFF
--- a/src/components/BaseIcon/BaseIcon.vue
+++ b/src/components/BaseIcon/BaseIcon.vue
@@ -16,7 +16,10 @@ import styles from '@whirli-local/components/BaseIcon/BaseIcon.module.scss';
 import { ConfigStyles, ConfigProps } from './BaseIcon.config';
 
 // Components
-import Icons from './Icons';
+import PackageIcons from './Icons';
+import { LocalIcons } from '@whirli-local/components/BaseIcon/BaseIcon.config';
+
+const Icons = { ...PackageIcons, ...LocalIcons };
 
 const ComponentStyles = ConfigStyles;
 import { PropKeys } from '@whirli-components/components/BaseIcon/BaseIcon.constants';

--- a/whirli/components/BaseIcon/BaseIcon.config.ts
+++ b/whirli/components/BaseIcon/BaseIcon.config.ts
@@ -2,6 +2,12 @@ import { ComponentStyles, ComponentProps, ComponentConfig } from '@whirli-compon
 
 import * as PropHelpers from '@whirli-components/helpers/props';
 
+// Local icons
+// import LocalIcon from './icons/LocalIcon.vue';
+export const LocalIcons: Record<string, any> = {
+  // LocalIcon,
+};
+
 const styles: ComponentStyles = {};
 
 const props: ComponentProps = {};


### PR DESCRIPTION
Any should stay here, Component type does not exist in '@vue/composition-api', would involve extra aliases in all apps.