### PR TITLE
[WHIR-3140] Remove necessity to set default breakpoint property for breakpoint props if its just the default value

### DIFF
--- a/src/@use/class.ts
+++ b/src/@use/class.ts
@@ -1,15 +1,22 @@
 import Breakpoints from '@whirli-components/styles/Breakpoints.module.scss';
-import { ComponentStyles } from '@whirli-components/@types/components';
+import { ComponentStyles, ComponentProps } from '@whirli-components/@types/components';
 
 interface Classes {
   /* eslint-disable  @typescript-eslint/no-explicit-any */
-  makeClasses: (config: ComponentStyles, props: Readonly<any>, styles: Record<string, string>) => string[];
+  makeClasses: (
+    config: ComponentStyles,
+    configProps: ComponentProps,
+    props: Readonly<any>,
+    styles: Record<string, string>
+  ) => string[];
   /* eslint-enable  @typescript-eslint/no-explicit-any */
 }
 
 export default function (): Classes {
   const makeClasses = (
     config: ComponentStyles,
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    configProps: ComponentProps,
     /* eslint-disable  @typescript-eslint/no-explicit-any */
     props: Readonly<any>,
     /* enable-disable  @typescript-eslint/no-explicit-any */
@@ -33,10 +40,12 @@ export default function (): Classes {
         } else {
           if (props[propKey]?.default) {
             defaultStyleKey = config[propKey].classes[props[propKey].default];
-            // Generate the default style
-            if (styles[defaultStyleKey]) {
-              classes.push(styles[defaultStyleKey]);
-            }
+          } else if (configProps[propKey].default) {
+            defaultStyleKey = config[propKey].classes[configProps[propKey].default];
+          }
+          // Generate the default style
+          if (defaultStyleKey && styles[defaultStyleKey]) {
+            classes.push(styles[defaultStyleKey]);
           }
         }
         // Generate the breakpoint styles
@@ -49,6 +58,7 @@ export default function (): Classes {
             classes.push(styles[breakpointStyleKey]);
           }
         });
+        console.log(classes);
       }
       // If there's no need to create breakpoint styles
       else {

--- a/src/components/BaseAccordion/BaseAccordion.vue
+++ b/src/components/BaseAccordion/BaseAccordion.vue
@@ -60,7 +60,7 @@ const accordionState: Record<string, string> = reactive({});
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const staticWrapperClasses = [...makeClasses(ComponentStyles, props, styles)];
+const staticWrapperClasses = [...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 const dynamicWrapperClasses: ComputedRef<string[]> = computed(() => [styles.accordion]);
 const wrapperClasses: ComputedRef<string[]> = computed(() => [
   ...staticWrapperClasses,

--- a/src/components/BaseAside/BaseAside.vue
+++ b/src/components/BaseAside/BaseAside.vue
@@ -20,5 +20,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.aside, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.aside, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseButton/BaseButton.vue
+++ b/src/components/BaseButton/BaseButton.vue
@@ -44,7 +44,7 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.button, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.button, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 
 const button: ComputedRef<any> = computed((): any => {
   return props.url !== undefined ? BaseButtonLink : BaseButtonDefault;

--- a/src/components/BaseColumn/BaseColumn.vue
+++ b/src/components/BaseColumn/BaseColumn.vue
@@ -18,5 +18,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.column, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.column, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseDivider/BaseDivider.vue
+++ b/src/components/BaseDivider/BaseDivider.vue
@@ -22,5 +22,5 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.divider, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.divider, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseFlex/BaseFlex.vue
+++ b/src/components/BaseFlex/BaseFlex.vue
@@ -24,5 +24,5 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles['base-flex'], ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles['base-flex'], ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseFormCheckbox/BaseFormCheckbox.vue
+++ b/src/components/BaseFormCheckbox/BaseFormCheckbox.vue
@@ -50,8 +50,8 @@ const { makeClasses } = useClasses();
 const classes = [
   sharedStyles['input-shared'],
   styles.checkbox,
-  ...makeClasses(ComponentStyles, props, styles),
-  ...makeClasses(ComponentStyles, props, sharedStyles),
+  ...makeClasses(ComponentStyles, ConfigProps, props, styles),
+  ...makeClasses(ComponentStyles, ConfigProps, props, sharedStyles),
 ];
 
 const updateValue: (event: Event) => void = (event: Event) => {

--- a/src/components/BaseFormError/BaseFormError.vue
+++ b/src/components/BaseFormError/BaseFormError.vue
@@ -23,5 +23,5 @@ const props: Props = defineProps(ConfigProps);
 import useClasses from '@whirli-components/@use/class';
 import BaseText from '@whirli-components/components/BaseText/BaseText.vue';
 const { makeClasses } = useClasses();
-const classes = [styles.error, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.error, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseFormGroup/BaseFormGroup.vue
+++ b/src/components/BaseFormGroup/BaseFormGroup.vue
@@ -22,5 +22,5 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes: string[] = [styles['form-group'], ...makeClasses(ComponentStyles, props, styles)];
+const classes: string[] = [styles['form-group'], ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseFormInput/BaseFormInput.vue
+++ b/src/components/BaseFormInput/BaseFormInput.vue
@@ -65,7 +65,11 @@ import BaseFormGroupLayoutDefault from '@whirli-components/components/BaseFormGr
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles['input-shared'], styles.input, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [
+  styles['input-shared'],
+  styles.input,
+  ...makeClasses(ComponentStyles, ConfigProps, props, styles),
+];
 
 const isTextarea = props[PropKeys.TYPE] === 'textarea';
 

--- a/src/components/BaseFormLabel/BaseFormLabel.vue
+++ b/src/components/BaseFormLabel/BaseFormLabel.vue
@@ -22,6 +22,6 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes: string[] = [styles.label, ...makeClasses(ComponentStyles, props, styles)];
+const classes: string[] = [styles.label, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 const requiredClass: string = props.required ? styles.required : '';
 </script>

--- a/src/components/BaseFormRadioButton/BaseFormRadioButton.vue
+++ b/src/components/BaseFormRadioButton/BaseFormRadioButton.vue
@@ -62,7 +62,7 @@ import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
 const wrapperClasses: ComputedRef<string[]> = computed(() => [
   styles['radio-button-wrapper'],
-  ...makeClasses(ComponentStyles, props, styles),
+  ...makeClasses(ComponentStyles, ConfigProps, props, styles),
 ]);
 const inputClasses: ComputedRef<string[]> = computed(() => [styles['radio-button-input']]);
 const displayClasses: ComputedRef<string[]> = computed(() => [styles['radio-button-display']]);

--- a/src/components/BaseFormSelect/BaseFormSelect.vue
+++ b/src/components/BaseFormSelect/BaseFormSelect.vue
@@ -45,8 +45,8 @@ const { makeClasses } = useClasses();
 const classes = [
   sharedStyles['input-shared'],
   styles.select,
-  ...makeClasses(ComponentStyles, props, styles),
-  ...makeClasses(ComponentStyles, props, sharedStyles),
+  ...makeClasses(ComponentStyles, ConfigProps, props, styles),
+  ...makeClasses(ComponentStyles, ConfigProps, props, sharedStyles),
 ];
 
 const updateValue: (event: Event) => void = (event: Event) => {

--- a/src/components/BaseGrid/BaseGrid.vue
+++ b/src/components/BaseGrid/BaseGrid.vue
@@ -18,5 +18,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.grid, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.grid, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseIcon/BaseIcon.vue
+++ b/src/components/BaseIcon/BaseIcon.vue
@@ -32,7 +32,7 @@ const props = defineProps(ConfigProps);
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
 const classes: ComputedRef<string[]> = computed((): string[] => {
-  return [styles.icon, ...makeClasses(ComponentStyles, props, styles)];
+  return [styles.icon, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 });
 
 // Get icon

--- a/src/components/BaseIconButton/BaseIconButton.vue
+++ b/src/components/BaseIconButton/BaseIconButton.vue
@@ -28,7 +28,10 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes: string[] = [styles['icon-button'], ...makeClasses(ComponentStyles, props, styles)];
+const classes: string[] = [
+  styles['icon-button'],
+  ...makeClasses(ComponentStyles, ConfigProps, props, styles),
+];
 const disabledClasses: ComputedRef<string> = computed(() =>
   props[PropKeys.IS_DISABLED] ? styles['is-disabled'] : ''
 );

--- a/src/components/BaseImage/BaseImage.vue
+++ b/src/components/BaseImage/BaseImage.vue
@@ -40,7 +40,7 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const wrapperClasses = [styles.image__wrapper, ...makeClasses(ComponentStyles, props, styles)];
+const wrapperClasses = [styles.image__wrapper, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 const imageClasses = [styles.image];
 
 // Component specific

--- a/src/components/BaseList/BaseList.vue
+++ b/src/components/BaseList/BaseList.vue
@@ -22,5 +22,5 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.list, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.list, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseMain/BaseMain.vue
+++ b/src/components/BaseMain/BaseMain.vue
@@ -20,5 +20,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.main, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.main, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseModal/BaseModal.vue
+++ b/src/components/BaseModal/BaseModal.vue
@@ -56,7 +56,7 @@ const emit = defineEmits(['modal:close', 'modal:open']);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const wrapperClasses = [styles.modal, ...makeClasses(ComponentStyles, props, styles)];
+const wrapperClasses = [styles.modal, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 const titleClasses = [styles['modal__title']];
 const contentClasses = [styles['modal__content']];
 

--- a/src/components/BaseOverlay/BaseOverlay.vue
+++ b/src/components/BaseOverlay/BaseOverlay.vue
@@ -27,7 +27,7 @@ const props = defineProps(ConfigProps);
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
 const wrapperClasses: ComputedRef<string[]> = computed(() => {
-  return [styles.overlay, ...makeClasses(ComponentStyles, props, styles)];
+  return [styles.overlay, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 });
 
 const contentClasses = [styles['overlay__content']];

--- a/src/components/BasePageNumber/BasePageNumber.vue
+++ b/src/components/BasePageNumber/BasePageNumber.vue
@@ -47,7 +47,7 @@ const tag: ComputedRef<string> = computed(() => (isActivePage.value ? 'div' : 'a
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const defaultClasses = [styles['page-number'], ...makeClasses(ComponentStyles, props, styles)];
+const defaultClasses = [styles['page-number'], ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 const activeClasses: ComputedRef<string> = computed(() => (isActivePage.value ? styles['is-active'] : ''));
 const disabledClasses: ComputedRef<string> = computed(() =>
   props[PropKeys.IS_DISABLED] ? styles['is-disabled'] : ''

--- a/src/components/BasePagination/BasePagination.vue
+++ b/src/components/BasePagination/BasePagination.vue
@@ -108,7 +108,7 @@ const isLastPage: ComputedRef<boolean> = computed(() => currentPage.value === pr
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const wrapperClasses = [styles.pagination, ...makeClasses(ComponentStyles, props, styles)];
+const wrapperClasses = [styles.pagination, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 
 function isCurrentPage(number: number): boolean {
   return number === currentPage.value;

--- a/src/components/BaseSection/BaseSection.vue
+++ b/src/components/BaseSection/BaseSection.vue
@@ -35,7 +35,7 @@ const props = defineProps(ConfigProps);
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
 const classes: ComputedRef<string[]> = computed((): string[] => {
-  return [styles.section, ...makeClasses(ComponentStyles, props, styles)];
+  return [styles.section, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 });
 
 const gutter: ComputedRef<ComputedSize> = computed(() => {

--- a/src/components/BaseSpacer/BaseSpacer.vue
+++ b/src/components/BaseSpacer/BaseSpacer.vue
@@ -18,5 +18,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.spacer, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.spacer, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseTag/BaseTag.vue
+++ b/src/components/BaseTag/BaseTag.vue
@@ -22,5 +22,5 @@ const props: Props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.tag, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.tag, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/components/BaseText/BaseText.vue
+++ b/src/components/BaseText/BaseText.vue
@@ -18,5 +18,5 @@ const props = defineProps(ConfigProps);
 // Classes
 import useClasses from '@whirli-components/@use/class';
 const { makeClasses } = useClasses();
-const classes = [styles.text, ...makeClasses(ComponentStyles, props, styles)];
+const classes = [styles.text, ...makeClasses(ComponentStyles, ConfigProps, props, styles)];
 </script>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="home">
-    <BaseFlex :direction="{ default: 'row', tablet: 'column' }">
+    <BaseFlex :direction="{ tablet: 'column' }">
       <BaseBox>Hello world</BaseBox><BaseBox>Hello world</BaseBox>
     </BaseFlex>
-    <BaseBox>Hello world</BaseBox>
+    <!--<BaseBox>Hello world</BaseBox>
     <BaseFormWrapper action="Test" @submit.prevent="alertMe()">
       <BaseFormInput
         type="email"
@@ -101,7 +101,7 @@
     </BaseList>
     <BaseTag>Hello world</BaseTag>
 
-    <BasePagination :first-page="1" :last-page="30" />
+    <BasePagination :first-page="1" :last-page="30" />-->
   </div>
 </template>
 

--- a/tests/unit/__snapshots__/BaseModal.spec.ts.snap
+++ b/tests/unit/__snapshots__/BaseModal.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`BaseModal.vue - Single classes renders the component 1`] = `
     
     <div
       aria-hidden="true"
-      aria-labelledby="7d732246-8cd9-464b-bb37-6aac5a0c8a97"
+      aria-labelledby="72bffbfa-8a61-4638-8049-df77c10fb237"
       aria-modal="true"
       class=""
       role="dialog"
@@ -20,7 +20,7 @@ exports[`BaseModal.vue - Single classes renders the component 1`] = `
       />
       <div
         class=""
-        id="7d732246-8cd9-464b-bb37-6aac5a0c8a97"
+        id="72bffbfa-8a61-4638-8049-df77c10fb237"
       >
         
         Modal title


### PR DESCRIPTION
If the direction prop has a default of “column” and we wanted it to be a “column” at mobile but “row” at small_desk, previously we’d have to write:


```
<MyComponent :direction="{ default: 'column', small_desk: 'row' }">
  Hello
</MyComponent>
```

We can now write:

```
<MyComponent :direction="{ small_desk: 'row' }">
  Hello
</MyComponent>
```